### PR TITLE
feat: add `useGlobalPkgs` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ We also can auto construct your hosts based on your file structure. Whilst provi
 
 - `easy-hosts.autoConstruct`: If set to true, the module will automatically construct the hosts for you from the directory structure of `easy-hosts.path`.
 
-- `easy-hosts.path`: The directory to where the hosts are stored, this *must* be set to use `easy-hosts.autoConstruct`.
+- `easy-hosts.useGlobalPkgs`: Set `nixpkgs.pkgs` to the `pkgs` instance from the flake-parts modules parameters instead of setting `nixpkgs.hostPlatform`.
+
+- `easy-hosts.path`: The directory to where the hosts are stored, this _must_ be set to use `easy-hosts.autoConstruct`.
 
 - `easy-hosts.onlySystem`: If you only have 1 system type like `aarch64-darwin` then you can use this setting to prevent nesting your directories.
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -62,6 +62,12 @@ in
         description = "Only construct the hosts with for this platform";
       };
 
+      useGlobalPkgs = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to use the `pkgs` instance from the flake parameters.";
+      };
+
       shared = mkBasicParams "Shared";
 
       perClass = mkOption {

--- a/lib.nix
+++ b/lib.nix
@@ -212,6 +212,7 @@ let
       system,
       nixpkgs,
       nix-darwin,
+      useGlobalPkgs ? false,
       modules ? [ ],
       specialArgs ? { },
       ...
@@ -289,7 +290,11 @@ let
           nixpkgs = {
             # you can also do this as `inherit system;` with the normal `lib.nixosSystem`
             # however for evalModules this will not work, so we do this instead
-            hostPlatform = mkDefault system;
+            hostPlatform = lib.mkIf (!useGlobalPkgs) (mkDefault system);
+
+            # use the `pkgs` instance from the flake-parts module parameters if `useGlobalPkgs`
+            # is enabled.
+            pkgs = lib.mkIf useGlobalPkgs (withSystem system ({ pkgs, ... }: pkgs));
 
             # The path to the nixpkgs sources used to build the system.
             # This is automatically set up to be the store path of the nixpkgs flake used to build
@@ -390,6 +395,8 @@ let
 
           output = mkHost {
             inherit name class;
+
+            inherit (easyHostsConfig) useGlobalPkgs;
 
             inherit (hostConfig)
               system


### PR DESCRIPTION
This PR adds a new option called `useGlobalPkgs` to the top-level easy-hosts configuration. When this option is enabled, the hosts will use the `pkgs` instance passed to the flake parameters instead of setting `nixpkgs.hostPlatform`. This is useful if you want to have a custom `pkgs` instance in your flake-parts config that can then be re-used for your hosts.

For example, I have this in my flake-parts configuration to create a custom pkgs instance with some configuration and overlays. Instead of having to re-define this in my host configuration, I can now enable this option and it will use this same `pkgs` instance:

```nix
{ inputs, ... }:
let
  config = {
    allowAliases = false;
    allowUnfree = true;
  };

  overlays = [
    inputs.agenix.overlays.default
    inputs.firefox-addons.overlays.default
    inputs.lix-module.overlays.default
    inputs.self.overlays.default
    inputs.tgirlpkgs.overlays.default
  ];
in
{
  perSystem =
    { system, ... }:
    {
      _module.args.pkgs = import inputs.nixpkgs { inherit system config overlays; };
    };

  easy-hosts.useGlobalPkgs = true; # All my hosts will now use this `pkgs` instance.
}
```